### PR TITLE
Remove custom imagemagick binary path

### DIFF
--- a/site/config/config.php
+++ b/site/config/config.php
@@ -10,7 +10,6 @@
 return [
     'debug' => true,
     'thumbs' => [
-        'driver' => 'im',
-        'bin' => '/opt/homebrew/bin/convert'
+        'driver' => 'im'
     ]
 ];


### PR DESCRIPTION
This threw an error when I gave this a try. I assume this path is custom to your setup and therefore would throw this error on most people's setup.